### PR TITLE
Fix Atolini receivables portador parsing

### DIFF
--- a/internal/api/handlers/converter_handler.go
+++ b/internal/api/handlers/converter_handler.go
@@ -196,7 +196,10 @@ func (h *ConverterHandler) HandleAtoliniRecebimentosConversion(c *gin.Context) {
 		return
 	}
 
-	classPrefixes := getPrefixesFromForm(c, "classPrefixes")
+	// Combina os prefixos de classe recebidos para débito e crédito
+	debitPrefixes := getPrefixesFromForm(c, "debitPrefixes")
+	creditPrefixes := getPrefixesFromForm(c, "creditPrefixes")
+	classPrefixes := append(debitPrefixes, creditPrefixes...)
 
 	csvFile, err := csvFileHeader.Open()
 	if err != nil {


### PR DESCRIPTION
## Summary
- preserve numeric prefixes in Atolini portador descriptions and stop treating them as lançamento rows
- merge debit and credit prefix parameters when processing Atolini receivables

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bced885688832d966070e19000c701