### PR TITLE
Add class prefix filters to Atolini recebimentos conversion

### DIFF
--- a/internal/api/handlers/converter_handler.go
+++ b/internal/api/handlers/converter_handler.go
@@ -184,9 +184,9 @@ func (h *ConverterHandler) HandleAtoliniPagamentosConversion(c *gin.Context) {
 
 // HandleAtoliniRecebimentosConversion lida com a conversão de recebimentos Atolini.
 func (h *ConverterHandler) HandleAtoliniRecebimentosConversion(c *gin.Context) {
-	csvFileHeader, err := c.FormFile("lancamentosFile")
+	excelFileHeader, err := c.FormFile("lancamentosFile")
 	if err != nil {
-		responses.Error(c, http.StatusBadRequest, "Arquivo de Lançamentos (.csv) não encontrado ou inválido")
+		responses.Error(c, http.StatusBadRequest, "Arquivo de Lançamentos (.xls, .xlsx) não encontrado ou inválido")
 		return
 	}
 
@@ -196,17 +196,15 @@ func (h *ConverterHandler) HandleAtoliniRecebimentosConversion(c *gin.Context) {
 		return
 	}
 
-	// Combina os prefixos de classe recebidos para débito e crédito
 	debitPrefixes := getPrefixesFromForm(c, "debitPrefixes")
 	creditPrefixes := getPrefixesFromForm(c, "creditPrefixes")
-	classPrefixes := append(debitPrefixes, creditPrefixes...)
 
-	csvFile, err := csvFileHeader.Open()
+	excelFile, err := excelFileHeader.Open()
 	if err != nil {
 		responses.Error(c, http.StatusInternalServerError, "Não foi possível abrir o arquivo de Lançamentos")
 		return
 	}
-	defer csvFile.Close()
+	defer excelFile.Close()
 
 	contasFile, err := contasFileHeader.Open()
 	if err != nil {
@@ -215,7 +213,7 @@ func (h *ConverterHandler) HandleAtoliniRecebimentosConversion(c *gin.Context) {
 	}
 	defer contasFile.Close()
 
-	outputCSV, err := h.service.ProcessAtoliniRecebimentos(csvFile, contasFile, classPrefixes)
+	outputCSV, err := h.service.ProcessAtoliniRecebimentos(excelFile, contasFile, debitPrefixes, creditPrefixes)
 	if err != nil {
 		fmt.Printf("Erro ao processar arquivos para Atolini Recebimentos: %v\n", err)
 		responses.Error(c, http.StatusInternalServerError, "Erro ao processar os arquivos", err.Error())

--- a/internal/core/converter/service.go
+++ b/internal/core/converter/service.go
@@ -27,7 +27,7 @@ type Service interface {
 	ProcessSicrediFiles(lancamentosFile io.Reader, contasFile io.Reader, lancamentosFilename string, classPrefixes []string) ([]byte, error)
 	ProcessReceitasAcisaFiles(excelFile io.Reader, contasFile io.Reader, excelFilename string, classPrefixes []string) ([]byte, error)
 	ProcessAtoliniPagamentos(excelFile io.Reader, contasFile io.Reader, debitPrefixes []string, creditPrefixes []string) ([]byte, error)
-	ProcessAtoliniRecebimentos(excelFile io.Reader, contasFile io.Reader, classPrefixes []string) ([]byte, error)
+	ProcessAtoliniRecebimentos(excelFile io.Reader, contasFile io.Reader, debitPrefixes []string, creditPrefixes []string) ([]byte, error)
 }
 
 type service struct{}
@@ -1633,7 +1633,7 @@ func findLastPortadorBefore(sheet [][]string, idx int, lookback int) (string, bo
 	return "", false
 }
 
-func (svc *service) ProcessAtoliniRecebimentos(excelFile io.Reader, contasFile io.Reader, classPrefixes []string) ([]byte, error) {
+func (svc *service) ProcessAtoliniRecebimentos(excelFile io.Reader, contasFile io.Reader, debitPrefixes []string, creditPrefixes []string) ([]byte, error) {
 	descricaoIndex, contasMap, err := svc.lerContasRecebimentos(contasFile)
 	if err != nil {
 		return nil, fmt.Errorf("erro ao carregar arquivo de contas: %w", err)
@@ -1696,7 +1696,7 @@ func (svc *service) ProcessAtoliniRecebimentos(excelFile io.Reader, contasFile i
 				currentCodDebito = "999999"
 			} else {
 				currentDescDebito = descDeb
-				currentCodDebito = svc.findContaCodigoByDescricao(currentDescDebito, descricaoIndex, contasMap, classPrefixes)
+				currentCodDebito = svc.findContaCodigoByDescricao(currentDescDebito, descricaoIndex, contasMap, debitPrefixes)
 				if currentCodDebito == "" {
 					currentCodDebito = "999999"
 				}
@@ -1725,7 +1725,7 @@ func (svc *service) ProcessAtoliniRecebimentos(excelFile io.Reader, contasFile i
 			if currentDescDebito == "" {
 				if p, ok := findLastPortadorBefore(rows, rIdx, 60); ok {
 					currentDescDebito = p
-					currentCodDebito = svc.findContaCodigoByDescricao(currentDescDebito, descricaoIndex, contasMap, classPrefixes)
+					currentCodDebito = svc.findContaCodigoByDescricao(currentDescDebito, descricaoIndex, contasMap, debitPrefixes)
 					if currentCodDebito == "" {
 						currentCodDebito = "999999"
 					}
@@ -1737,7 +1737,7 @@ func (svc *service) ProcessAtoliniRecebimentos(excelFile io.Reader, contasFile i
 			// remover possíveis prefixos numéricos residuais
 			descCredito = stripLeadingNumberPrefix(descCredito)
 
-			codCredito := svc.findContaCodigoByDescricao(descCredito, descricaoIndex, contasMap, classPrefixes)
+			codCredito := svc.findContaCodigoByDescricao(descCredito, descricaoIndex, contasMap, creditPrefixes)
 			if codCredito == "" {
 				codCredito = "999999"
 			}


### PR DESCRIPTION
## Summary
- support separate debit and credit class prefix filters in Atolini Recebimentos
- pass debit/credit filters from handler and document expected Excel input

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bf08972264832d92363d76cd918841